### PR TITLE
fix: breakpoint variants should apply only to the owned rules

### DIFF
--- a/src/preset.ts
+++ b/src/preset.ts
@@ -7,12 +7,6 @@ import { createRtlRules, createVariants } from './variants'
 export function presetVuetify (options: PresetVuetifyOptions = {}): Preset {
   const rules = [...createRules(options), ...createRtlRules(options)]
 
-  const staticRuleNames = new Set(
-    rules
-      .filter(r => typeof r[0] === 'string')
-      .map(r => r[0] as string),
-  )
-
   return {
     name: 'unocss-preset-vuetify',
     layers: {
@@ -20,7 +14,7 @@ export function presetVuetify (options: PresetVuetifyOptions = {}): Preset {
       utilities: 0,
     },
     rules,
-    variants: createVariants(options, staticRuleNames),
+    variants: createVariants(options, rules),
     preflights: preflights(options),
     postprocess (util) {
       if (!options.important) {

--- a/src/variants/breakpoints.ts
+++ b/src/variants/breakpoints.ts
@@ -1,10 +1,19 @@
-import type { Variant } from 'unocss'
+import type { Rule, Variant } from 'unocss'
 import type { PresetVuetifyOptions } from '../theme'
 import { defaultBreakpoints } from '../theme'
 
-export function breakpointVariants (options: PresetVuetifyOptions, staticRuleNames: Set<string>): Variant[] {
+export function breakpointVariants (options: PresetVuetifyOptions, rules: Rule[]): Variant[] {
   const breakpoints = options.breakpoints ?? defaultBreakpoints
   const variants: Variant[] = []
+
+  const matchers = rules.map(rule => rule[0])
+  const staticRuleNames = new Set<string>(matchers.filter(key => typeof key === 'string'))
+  const dynamicRulePatterns: RegExp[] = matchers.filter(key => key instanceof RegExp)
+
+  function isVuetifyRule (name: string) {
+    return staticRuleNames.has(name)
+      || dynamicRulePatterns.some(pattern => pattern.test(name))
+  }
 
   for (const [name, minWidth] of Object.entries(breakpoints)) {
     variants.push({
@@ -20,6 +29,13 @@ export function breakpointVariants (options: PresetVuetifyOptions, staticRuleNam
         const regex = new RegExp(`^(.+)-${name}$`)
         const match = matcher.match(regex)
         if (!match) {
+          return
+        }
+
+        // Only apply the breakpoint variant when the base is a Vuetify rule.
+        // Otherwise classes like `text-lg` / `text-xl` from other presets would
+        // be stripped to `text` and fail to resolve.
+        if (!isVuetifyRule(match[1])) {
           return
         }
 

--- a/src/variants/index.ts
+++ b/src/variants/index.ts
@@ -1,13 +1,13 @@
-import type { Variant } from 'unocss'
+import type { Rule, Variant } from 'unocss'
 import type { PresetVuetifyOptions } from '../theme'
 import { breakpointVariants } from './breakpoints'
 import { printVariant } from './print'
 import { createThemeVariants } from './themes'
 import { visibilityVariants } from './visibility'
 
-export function createVariants (options: PresetVuetifyOptions, staticRuleNames: Set<string>): Variant[] {
+export function createVariants (options: PresetVuetifyOptions, rules: Rule[]): Variant[] {
   return [
-    ...breakpointVariants(options, staticRuleNames),
+    ...breakpointVariants(options, rules),
     ...visibilityVariants(options),
     printVariant(),
     ...(options.themes ? createThemeVariants(options.themes) : []),


### PR DESCRIPTION
Breakpoint variants are a bit too invasive. We can scope them to owned rules.

fixes #16